### PR TITLE
align aiChat handler return type with Express RequestHandler

### DIFF
--- a/src/controllers/course.controller.ts
+++ b/src/controllers/course.controller.ts
@@ -83,11 +83,13 @@ class CourseController {
     } catch (err: any) {
       if (err.response?.status === StatusCodes.RATE_LIMIT) {
         console.error("Gemini rate limit error:", err);
-        return res
+        res
           .status(StatusCodes.RATE_LIMIT)
           .json(
             errorResponse("AI service limit reached. Please try again later.")
           );
+
+        return;
       }
 
       next(err);


### PR DESCRIPTION
### Changes
- Removed `return res...` statements from `aiChat` handler.  
- Ensured handler no longer returns `Response` objects, matching Express `RequestHandler` typing (`void | Promise<void>`).  

### Impact
- Eliminates TypeScript error:  
  `Type 'Promise<Response | undefined>' is not assignable to type 'Promise<void>'`.  
- Improves type safety while preserving existing runtime behavior.  
